### PR TITLE
Deploy backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,7 @@ workflows:
           requires:
             - test_frontend
             - test_backend
+            - docker_build_backend
           filters:
             branches:
               only:

--- a/main.tf
+++ b/main.tf
@@ -10,19 +10,30 @@ provider "aws" {
   # Empty because AWS credentials are passed through env variables
 }
 
-resource "aws_instance" "example" {
-  ami = "ami-db710fa3"
+resource "aws_instance" "backend" {
+  ami = "ami-8faee3f7"
   instance_type = "t2.micro"
   key_name = "sudokurace"
-  vpc_security_group_ids = ["${aws_security_group.instance.id}"]
+  vpc_security_group_ids = ["${aws_security_group.backend.id}"]
+  iam_instance_profile = "SudokuRaceBackendRole"
+
+  user_data = <<-EOF
+              #!/bin/sh
+              eval $(sudo aws ecr get-login --no-include-email --region us-west-2)
+              sudo docker run --restart always -d -p"${var.server_port}":8080  717012417639.dkr.ecr.us-west-2.amazonaws.com/sudokurace:latest
+              EOF
+
+  lifecycle {
+    create_before_destroy = true
+  }
 
   tags {
-    Name = "terraform-example"
+    Name = "sudokurace-backend"
   }
 }
 
-resource "aws_security_group" "instance" {
-  name = "terraform-example-instance"
+resource "aws_security_group" "backend" {
+  name = "backend-sg"
 
   ingress {
     from_port = "${var.server_port}"
@@ -36,5 +47,21 @@ resource "aws_security_group" "instance" {
     to_port = "22"
     protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "backend" {
+  zone_id = "Z3M4U9F1SEVV2O"
+  name = "backend.sudokurace.io"
+  type = "A"
+  ttl = "5"
+  records = ["${aws_instance.backend.public_ip}"]
+
+  lifecycle {
+    create_before_destroy = true
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "public_ip" {
-  value = "${aws_instance.example.public_ip}"
+  value = "${aws_instance.backend.public_ip}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
 variable "server_port" {
   description = "The HTTP server port"
-  default = 8080
+  default = 80
 }


### PR DESCRIPTION
Our terraform configuration now has an EC2 instance that loads, which
has a custom AMI with docker installed. Upon boot up, the AMI will login
to ECR which is hosting our backend docker image, and then will run the
docker image as a docker daemon.

On top of that, the terraform config creates a domain,
backend.sudokurace.io, which will always be set to the IP address of the
EC2 instance, and all traffic gets forwarded to that instance, so we can
always send requests to backend.sudokurace.io instead of having to worry
about the IP address of the instance itself.