### PR TITLE
Use ELB with SSL termination

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,7 @@ jobs:
             curl "https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip" -o "terraform.zip"
             unzip terraform.zip
             ./terraform init -input=false
+            ./terraform taint aws_autoscaling_group.backend
             ./terraform plan -out=tfplan.txt -input=false
             ./terraform apply -input=false -auto-approve tfplan.txt
       - store_artifacts:

--- a/main.tf
+++ b/main.tf
@@ -10,25 +10,54 @@ provider "aws" {
   # Empty because AWS credentials are passed through env variables
 }
 
-resource "aws_instance" "backend" {
-  ami = "ami-8faee3f7"
+data "aws_availability_zones" "all" {}
+
+resource "aws_launch_configuration" "backend" {
+  image_id = "ami-8faee3f7"
   instance_type = "t2.micro"
   key_name = "sudokurace"
-  vpc_security_group_ids = ["${aws_security_group.backend.id}"]
   iam_instance_profile = "SudokuRaceBackendRole"
+  security_groups = ["${aws_security_group.backend.id}"]
+  associate_public_ip_address = false
 
   user_data = <<-EOF
               #!/bin/sh
               eval $(sudo aws ecr get-login --no-include-email --region us-west-2)
-              sudo docker run --restart always -d -p"${var.server_port}":8080  717012417639.dkr.ecr.us-west-2.amazonaws.com/sudokurace:latest
+              sudo docker run --restart always -d -p"${var.server_port}":8080 717012417639.dkr.ecr.us-west-2.amazonaws.com/sudokurace:latest
               EOF
 
   lifecycle {
     create_before_destroy = true
   }
+}
 
-  tags {
-    Name = "sudokurace-backend"
+resource "aws_autoscaling_group" "backend" {
+  launch_configuration = "${aws_launch_configuration.backend.id}"
+  availability_zones = ["${data.aws_availability_zones.all.names}"]
+
+  min_size = 1
+  max_size = 1
+
+  load_balancers = ["${aws_elb.backend.name}"]
+
+  tag {
+    key = "Name"
+    value = "backend-asg"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_elb" "backend" {
+  name = "backend-elb"
+  security_groups = ["${aws_security_group.elb.id}"]
+  availability_zones = ["${data.aws_availability_zones.all.names}"]
+
+  listener {
+    lb_port = 443
+    lb_protocol = "https"
+    instance_port = "${var.server_port}"
+    instance_protocol = "http"
+    ssl_certificate_id = "arn:aws:acm:us-west-2:717012417639:certificate/95a0de96-0eaa-4c61-8a24-80bac18c13e6"
   }
 }
 
@@ -39,14 +68,7 @@ resource "aws_security_group" "backend" {
     from_port = "${var.server_port}"
     to_port = "${var.server_port}"
     protocol = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port = "22"
-    to_port = "22"
-    protocol = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    security_groups = ["${aws_security_group.elb.id}"]
   }
 
   lifecycle {
@@ -54,12 +76,30 @@ resource "aws_security_group" "backend" {
   }
 }
 
+resource "aws_security_group" "elb" {
+  name = "elb-sg"
+
+  ingress {
+    from_port = "443"
+    to_port = "443"
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
 resource "aws_route53_record" "backend" {
   zone_id = "Z3M4U9F1SEVV2O"
   name = "backend.sudokurace.io"
-  type = "A"
+  type = "CNAME"
   ttl = "5"
-  records = ["${aws_instance.backend.public_ip}"]
+  records = ["${aws_elb.backend.dns_name}"]
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,10 @@ resource "aws_autoscaling_group" "backend" {
     value = "backend-asg"
     propagate_at_launch = true
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_elb" "backend" {
@@ -58,6 +62,10 @@ resource "aws_elb" "backend" {
     instance_port = "${var.server_port}"
     instance_protocol = "http"
     ssl_certificate_id = "arn:aws:acm:us-west-2:717012417639:certificate/95a0de96-0eaa-4c61-8a24-80bac18c13e6"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 
@@ -91,6 +99,10 @@ resource "aws_security_group" "elb" {
     to_port = 0
     protocol = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,0 @@
-output "public_ip" {
-  value = "${aws_instance.backend.public_ip}"
-}


### PR DESCRIPTION
Now we're using a classic load balancer with an auto-scaling group with
a single instance. Right now we're putting all game state in the RAM of
the local instance, so we can't actually scale to more than one
instance. We'll fix that in the near future.

Until then, we'll run with a single instance. At the same time, now that
there's a load balancer in front of our auto scaling group, we can
configure the load balancer to have the SSL termination. I've disabled
http://backend.sudokurace.io, and now all traffic must be encrypted at
https://backend.sudokurace.io.