### PR TITLE
Use public host

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,8 @@ workflows:
       - terraform_apply:
           requires:
             - test_frontend
+            - test_backend
+            - docker_build_backend
           filters:
             branches:
               only:

--- a/backend/runserver.py
+++ b/backend/runserver.py
@@ -1,4 +1,4 @@
 from sudokurace import app
 
 if __name__ == '__main__':
-    app.run('0.0.0.0', debug=app.config['DEBUG'])
+    app.run(host='0.0.0.0', debug=app.config['DEBUG'])

--- a/backend/tools/static_analysis.sh
+++ b/backend/tools/static_analysis.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-for pythonFile in `find backend -name "*.py"`; do
-  echo "Checking $pythonFile"
-  flake8 --show-source $pythonFile || exit 1
-done


### PR DESCRIPTION
The server was still running on localhost because in Sanic, the host is
a keyword argument, not a positional argument.