### PR TITLE
Stop using latest on deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - run:
           name: "Build & push Docker image"
           command: |
-            docker build -t $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:latest -t $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:$CIRCLE_SHA1 -f backend/Dockerfile backend
+            docker build -t $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:prod -t $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:$CIRCLE_SHA1 -f backend/Dockerfile backend
             docker push $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:$CIRCLE_SHA1
 
   terraform_apply:

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "aws_launch_configuration" "backend" {
   user_data = <<-EOF
               #!/bin/sh
               eval $(sudo aws ecr get-login --no-include-email --region us-west-2)
-              sudo docker run --restart always -d -p"${var.server_port}":8000 717012417639.dkr.ecr.us-west-2.amazonaws.com/sudokurace:latest
+              sudo docker run --restart always -d -p"${var.server_port}":8000 717012417639.dkr.ecr.us-west-2.amazonaws.com/sudokurace:prod
               EOF
 
   lifecycle {


### PR DESCRIPTION
The latest tag in Docker does not actually always run the latest docker
image. You can read more here:
https://medium.com/@mccode/the-misunderstood-docker-tag-latest-af3babfd6375

Basically, latest just doesn't work.