### PR TITLE
Use latest tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,8 @@ jobs:
       - run:
           name: "Build & push Docker image"
           command: |
-            docker build -t $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:prod -t $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:$CIRCLE_SHA1 -f backend/Dockerfile backend
+            docker build -t $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:latest -t $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:$CIRCLE_SHA1 -f backend/Dockerfile backend
+            docker push $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:latest
             docker push $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:$CIRCLE_SHA1
 
   terraform_apply:

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "aws_launch_configuration" "backend" {
   user_data = <<-EOF
               #!/bin/sh
               eval $(sudo aws ecr get-login --no-include-email --region us-west-2)
-              sudo docker run --restart always -d -p"${var.server_port}":8000 717012417639.dkr.ecr.us-west-2.amazonaws.com/sudokurace:prod
+              sudo docker run --restart always -d -p"${var.server_port}":8000 717012417639.dkr.ecr.us-west-2.amazonaws.com/sudokurace:latest
               EOF
 
   lifecycle {


### PR DESCRIPTION
The problem was that I was never actually pushing the Docker image that
was tagged to be latest. I thought what was going on, was that since the
image had a tag for the $CIRCLE_SHA1, that it would also push to the
latest tag, because they were technically the same image.