### PR TITLE
Fix backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,8 +91,7 @@ jobs:
       - run:
           name: "Build & push Docker image"
           command: |
-            docker build -t $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:latest -t $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:$CIRCLE_SHA1 -f backend/Dockerfile backend
-            docker push $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:latest
+            docker build -t $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:$CIRCLE_SHA1 -f backend/Dockerfile backend
             docker push $AWS_ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/sudokurace:$CIRCLE_SHA1
 
   terraform_apply:
@@ -104,6 +103,7 @@ jobs:
       - run:
           name: "Apply Terraform plan"
           command: |
+            export TF_VAR_tag=$CIRCLE_SHA1
             curl "https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip" -o "terraform.zip"
             unzip terraform.zip
             ./terraform init -input=false

--- a/backend/sudokurace/views/game.py
+++ b/backend/sudokurace/views/game.py
@@ -8,5 +8,6 @@ from sanic.response import json
 async def root(req):
     return json({
         'id': 0,
-        'board': ' 5248937673925684146837129538712465959176342824689'
+        'board': ('    735     6   9486 4     34   71             52   '
+                '87     4 3297   8     413    ')
     })

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
 data "aws_availability_zones" "all" {}
 
 resource "aws_launch_configuration" "backend" {
-  image_id = "ami-8faee3f7"
+  image_id = "ami-8c0d44f4"
   instance_type = "t2.micro"
   key_name = "sudokurace"
   iam_instance_profile = "SudokuRaceBackendRole"
@@ -22,8 +22,8 @@ resource "aws_launch_configuration" "backend" {
 
   user_data = <<-EOF
               #!/bin/sh
-              eval $(sudo aws ecr get-login --no-include-email --region us-west-2)
-              sudo docker run --restart always -d -p"${var.server_port}":8000 717012417639.dkr.ecr.us-west-2.amazonaws.com/sudokurace:latest
+              eval $(aws ecr get-login --no-include-email --region us-west-2)
+              docker run --restart always -d -p"${var.server_port}":8000 717012417639.dkr.ecr.us-west-2.amazonaws.com/sudokurace:${var.tag}
               EOF
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -2,3 +2,7 @@ variable "server_port" {
   description = "The HTTP server port"
   default = 80
 }
+
+variable "tag" {
+  description = "Tag to use for this deployment"
+}


### PR DESCRIPTION
_**Specify the CIRCLE_SHA1 for the docker image**_

This is a combination of fixes to make the backend work again.

Firstly, the AMI that was being used, was actually snapshotted with a
java docker image running, by default. I've fixed that, and created a
new AMI.

Second, the latest tag was being unreliable, so I've removed any need
for it, by passing in the correct CIRCLE_SHA1 directly into the
terraform configuration, so that the user_data of the launched instances
know which explicit image to use.

I tested this by bypassing the filter on the CircleCI build workflow
configuration, but I can finally confirm that this actually deploys and
works as expected.

_**Use a real board as the game.create response**_

Prior to this, I was sending only 50 characters, which was because I
incorrectly copy pasted the board string from the original Java code
base's "core" module, but I forgot to copy everything on the second
line. Now we'll send a full board

