### PR TITLE
Fix circleci again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
 
   docker_build:
     docker:
-      - image: python:3.6-stretch
+      - image: circleci/openjdk:8-jdk
     steps:
       - checkout
       - setup_remote_docker
@@ -97,6 +97,7 @@ workflows:
             - lint_git_commits
       - docker_build:
           requires:
+            - test_frontend
             - test_backend
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
 
   docker_build:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: python:3.6-stretch
     steps:
       - checkout
       - setup_remote_docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN npm run-script build
 
 # Copy built frontend bundle to backend
 WORKDIR /app
-COPY /frontend/build /app/static/
+RUN mkdir -p /app/static
+RUN cp -r /frontend/build/* /app/static/
 RUN mv /app/static/static/* /app/static/ && rm -rf /app/static/static
 
 # Multi-stage build, so that our final container doesn't include node_modules


### PR DESCRIPTION
_**Explicitly create directories for CircleCI**_

It appears as though the version of Docker that CircleCI uses doesn't
work quite the same way as the Docker I've been using on my local
machine.

_**Require all tests to pass before building container**_

Now that both the frontend and backend are being packaged together, we
need to make sure that both sets of tests pass before the actual
container gets built and pushed to ECR.

