### PR TITLE
Set no cache for index html

### DIFF
--- a/backend/sudokurace/__init__.py
+++ b/backend/sudokurace/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3.6
 from sanic import Sanic
 from sanic_cors import CORS
+from sanic.response import html
 
 app = Sanic(__name__)
 CORS(app)
@@ -10,8 +11,13 @@ try:
 except IOError as e:  # pragma: no cover
     ...
 
-app.static('/', './static/index.html')
 app.static('/static', './static')
 app.static('/service-worker.js', 'static/service-worker.js')
+
+
+@app.route('/')
+async def root(req):
+    return html(open('./static/index.html').read(),
+                headers={'Cache-Control': 'no-cache'})
 
 from . import views  # noqa

--- a/frontend/src/Board.jsx
+++ b/frontend/src/Board.jsx
@@ -13,7 +13,7 @@ class Board extends Component {
   }
 
   componentDidMount() {
-    fetch('https://backend.sudokurace.io/game.create')
+    fetch('https://www.sudokurace.io/game.create')
       .then(resp => resp.json())
       .then(json => json.board.split(''))
       .then(board => this.setState({board}))

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_elb" "backend" {
     lb_protocol = "https"
     instance_port = "${var.server_port}"
     instance_protocol = "http"
-    ssl_certificate_id = "arn:aws:acm:us-west-2:717012417639:certificate/95a0de96-0eaa-4c61-8a24-80bac18c13e6"
+    ssl_certificate_id = "arn:aws:acm:us-west-2:717012417639:certificate/64c97d07-84b2-43ad-857c-941a14053c69"
   }
 
   lifecycle {
@@ -108,7 +108,7 @@ resource "aws_security_group" "elb" {
 
 resource "aws_route53_record" "backend" {
   zone_id = "Z3M4U9F1SEVV2O"
-  name = "backend.sudokurace.io"
+  name = "www.sudokurace.io"
   type = "CNAME"
   ttl = "5"
   records = ["${aws_elb.backend.dns_name}"]


### PR DESCRIPTION
_**Set no-cache for the main page**_

index.html has references to uniquely named resource IDs. The main.XXX.js
and main.XXX.css have a unique identifiers in them so that if they get
cached by CloudFront, there won't be a problem for the browser, because
the browser will have to request these uniquely named resources. Even if
these uniquely named resources get cached, and we do a new deployment,
the newly build index.html will have a reference to a new set of
resources, which will make the browser request the new resources. So
we'll never have to worry about the main.XXX.js/css files being
de-synced from the backend.

The problem that remains, is if a browser/client caches the index.html
file. Then when we deploy a new version of our application, the old
index.html page with the wrong main.js/css files will get loaded. We
can't have the same approach of uniquely naming our index.html, because
then people will have to try navigating to a strangely named index page.
The solution here is to make sure that when we send back a response for
the index.html, we specify to browsers to never cache this page, so that
every single time someone comes to visit the index.html, they have to
re-download it, and see if the main.js/css pages have been updated.

_**Switch to using www for the whole app**_

Instead of having backend.sudokurace.io, just use www.sudokurace.io.
This doesn't handle redirects from http to https, or from the naked
domain to the www domain. We can do that in the future through
CloudFront but for now it doesn't really matter.

