### PR TITLE
Set up CloudFront caching and naked domain redirect

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,31 @@ provider "aws" {
   # Empty because AWS credentials are passed through env variables
 }
 
+locals {
+  elb_origin_id = "ELB-backend-elb"
+}
+
 data "aws_availability_zones" "all" {}
+
+# This bucket receives requests to "sudokurace.io" for redirecting
+resource "aws_s3_bucket" "redirect" {
+  website {
+    redirect_all_requests_to = "www.sudokurace.io"
+  }
+}
+
+# Route requests to "sudokurace.io" to our CloudFront distribution
+resource "aws_route53_record" "redirect" {
+  zone_id = "${data.aws_route53_zone.zone.id}"
+  name = "sudokurace.io"
+  type = "A"
+
+  alias {
+    name = "${aws_cloudfront_distribution.distribution.domain_name}"
+    zone_id = "${aws_cloudfront_distribution.distribution.hosted_zone_id}"
+    evaluate_target_health = "false"
+  }
+}
 
 resource "aws_launch_configuration" "backend" {
   image_id = "ami-8c0d44f4"
@@ -61,7 +85,7 @@ resource "aws_elb" "backend" {
     lb_protocol = "https"
     instance_port = "${var.server_port}"
     instance_protocol = "http"
-    ssl_certificate_id = "arn:aws:acm:us-west-2:717012417639:certificate/64c97d07-84b2-43ad-857c-941a14053c69"
+    ssl_certificate_id = "${aws_acm_certificate.cert.arn}"
   }
 
   lifecycle {
@@ -106,12 +130,94 @@ resource "aws_security_group" "elb" {
   }
 }
 
+resource "aws_acm_certificate" "cert" {
+  domain_name = "www.sudokurace.io"
+  subject_alternative_names = ["sudokurace.io"]
+  validation_method = "DNS"
+}
+
+data "aws_route53_zone" "zone" {
+  name = "sudokurace.io."
+  private_zone = false
+}
+
+resource "aws_route53_record" "cert_validation" {
+  name = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
+  type = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
+  zone_id = "${data.aws_route53_zone.zone.id}"
+  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
+  ttl = 60
+}
+
+resource "aws_route53_record" "cert_validation_alt1" {
+  name = "${aws_acm_certificate.cert.domain_validation_options.1.resource_record_name}"
+  type = "${aws_acm_certificate.cert.domain_validation_options.1.resource_record_type}"
+  zone_id = "${data.aws_route53_zone.zone.id}"
+  records = ["${aws_acm_certificate.cert.domain_validation_options.1.resource_record_value}"]
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn = "${aws_acm_certificate.cert.arn}"
+  validation_record_fqdns = [
+    "${aws_route53_record.cert_validation.fqdn}",
+    "${aws_route53_record.cert_validation_alt1.fqdn}"
+  ]
+}
+
+resource "aws_cloudfront_distribution" "distribution" {
+  origin {
+    domain_name = "${aws_elb.backend.dns_name}"
+    origin_id = "${local.elb_origin_id}"
+
+    custom_origin_config {
+      http_port = 80
+      https_port = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols = ["TLSv1", "TLSv1.1", "TLSv1.2", "SSLv3"]
+    }
+  }
+
+  enabled = true
+
+  aliases = ["www.sudokurace.io", "sudokurace.io"]
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "${local.elb_origin_id}"
+
+    forwarded_values {
+      query_string = false
+      headers = ["Host"]
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    compress = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    # Manually created certificate. Apparently CloudFront can only use certs from us-east-1
+    acm_certificate_arn = "arn:aws:acm:us-east-1:717012417639:certificate/8c310d5f-7e0f-4fc4-bb59-538ff047e946"
+    ssl_support_method = "sni-only"
+  }
+}
+
 resource "aws_route53_record" "backend" {
-  zone_id = "Z3M4U9F1SEVV2O"
+  zone_id = "${data.aws_route53_zone.zone.id}"
   name = "www.sudokurace.io"
   type = "CNAME"
   ttl = "5"
-  records = ["${aws_elb.backend.dns_name}"]
+  records = ["${aws_cloudfront_distribution.distribution.domain_name}"]
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
Setup caching for the load balancer, so that CloudFront can cache the
static resources that get returned by the load balancer.