### PR TITLE
Implement sudoku solver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - checkout
       - run: pip install pipenv
       - run: cd backend && pipenv install --dev
-      - run: cd backend && pipenv run flake8 --show-source
+      - run: cd backend && pipenv run flake8 --show-source --import-order-style pep8
       - run: cd backend && pipenv run pytest --cov-report html --junit-xml=coverage.xml --cov-branch --cov-fail-under=90 -v --cov=sudokurace tests/
       - run: mkdir -p backend/test-results/pytest && cp backend/coverage.xml backend/test-results/pytest/results.xml
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .terraform
+.pytest_cache

--- a/backend/sudokurace/__init__.py
+++ b/backend/sudokurace/__init__.py
@@ -3,7 +3,6 @@ import logging
 
 from sanic import Sanic
 from sanic.response import html
-
 from sanic_cors import CORS
 
 logging.getLogger().setLevel(logging.INFO)

--- a/backend/sudokurace/core.py
+++ b/backend/sudokurace/core.py
@@ -1,27 +1,112 @@
-from collections import defaultdict
+# Based heavily on: http://norvig.com/sudoku.html
 
 
-def is_valid_set(char_set):
-    """Checks if a given 9 character string is possibly a valid sudoku move"""
+def cross(a, b):
+    """Cross product of elements in A and elements in B.
+    """
+    return [_a + _b for _a in a for _b in b]
 
-    if len(char_set) < 9:
+
+digits = '123456789'
+rows = 'ABCDEFGHI'
+cols = digits
+squares = cross(rows, cols)
+unitlist = ([cross(rows, c) for c in cols] +
+            [cross(r, cols) for r in rows] +
+            [cross(rs, cs) for rs in ('ABC', 'DEF', 'GHI')
+                for cs in ('123', '456', '789')])
+units = {s: [u for u in unitlist if s in u] for s in squares}
+peers = {s: set(sum(units[s], [])) - {s} for s in squares}
+
+
+def parse_grid(grid):
+    """Convert grid to a dict of possible values, {square: digits}, or
+    return False if a contradiction is detected.
+    """
+    # To start, every square can be any digit; then assign values from the grid
+    values = {s: digits for s in squares}
+    for s, d in grid_values(grid).items():
+        if d in digits and not assign(values, s, d):
+            return False  # (Fail if we can't assign d to square s.)
+    return values
+
+
+def grid_values(grid):
+    """Convert grid into a dict of {square: char} with '0' or '.' for empties.
+    """
+    chars = [c for c in grid if c in digits or c in ' ']
+    return dict(zip(squares, chars))
+
+
+def assign(values, s, d):
+    """Eliminate all the other values (except d) from values[s] and propagate.
+    Return values, except return False if a contradiction is detected.
+    """
+    other_values = values[s].replace(d, '')
+    if all(eliminate(values, s, d2) for d2 in other_values):
+        return values
+    else:
         return False
 
-    # We skip spaces, so we can't just rely on collections.Counter
-    count = defaultdict(int)
-    for c in char_set:
-        if c == ' ':
-            continue
-        if int(c) < 1 or 9 < int(c):
+
+def eliminate(values, s, d):
+    """Eliminate d from values[s]; propagate when values or places <= 2.
+    Return values, except return False if a contradiction is detected.
+    """
+    if d not in values[s]:
+        return values  # Already eliminated
+    values[s] = values[s].replace(d, '')
+    # (1) If a square s is reduced to one value d2, then eliminate d2 from the
+    # peers.
+    if len(values[s]) == 1:
+        d2 = values[s]
+        if not all(eliminate(values, s2, d2) for s2 in peers[s]):
             return False
-        count[c] += 1
-    return all({char_count < 2 for char_count in count.values()})
+    # (2) If a unit u is reduced to only one place for a value d, then put it
+    # there.
+    for u in units[s]:
+        dplaces = [s for s in u if d in values[s]]
+        if len(dplaces) == 0:
+            return False  # Contradiction: no place for this value
+        elif len(dplaces) == 1:
+            # d can only be in one place in unit; assign it there
+            if not assign(values, dplaces[0], d):
+                return False
+    return values
 
 
-def is_valid_board(board):
-    if len(board) != 81:
-        return False
-    rows = {board[i * 9:(i * 9) + 10] for i in range(9)}
-    # Transpose the rows to get the columns as rows for easier usage
-    cols = {''.join(x) for x in zip(*rows)}
-    return all({is_valid_set(char_set) for char_set in rows.union(cols)})
+def display(values):
+    """Display these values as a 2-D grid.
+    """
+    displayable = ''
+    width = 1 + max(len(values[s]) for s in squares)
+    line = '+'.join(['-'*(width*3)]*3)
+    for r in rows:
+        displayable += ''.join(values[r+c].center(width) +
+                               ('|' if c in '36' else '')
+                               for c in cols)
+        displayable += '\n'
+        if r in 'CF':
+            displayable += line
+            displayable += '\n'
+    displayable += '\n'
+    return displayable
+
+
+def solve(grid):
+    return search(parse_grid(grid))
+
+
+def search(values):
+    """Using depth-first search and propagation, try all possible values.
+    """
+    if values is False:
+        return False  # Failed earlier
+    if all(len(values[s]) == 1 for s in squares):
+        return values  # Solved!
+    # Chose the unfilled square s with the fewest possibilities
+    n, s = min((len(values[s]), s) for s in squares if len(values[s]) > 1)
+    for d in values[s]:
+        result = search(assign(values.copy(), s, d))
+        if result:
+            return result

--- a/backend/sudokurace/models/state.py
+++ b/backend/sudokurace/models/state.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3.6
-from sudokurace.core import is_valid_board
+from sudokurace.core import solve
 
 # Global state, will need to store this externally, eventually
 game_state = {}
@@ -31,7 +31,7 @@ def make_move(game_id, move):
         new_board = current_board[:pos] + m['char'] + \
             current_board[pos + 1:]
 
-        if not is_valid_board(new_board):
+        if not solve(new_board):
             return {'id': game_id, 'board': current_board}
 
         current_board = new_board

--- a/backend/sudokurace/models/state.py
+++ b/backend/sudokurace/models/state.py
@@ -5,6 +5,12 @@ from sudokurace.core import solve
 game_state = {}
 
 
+class Status():
+    INVALID = 'INVALID'
+    INCOMPLETE = 'INCOMPLETE'
+    COMPLETE = 'COMPLETE'
+
+
 def create_game():
     new_id = len(game_state.keys())
     game_state[new_id] = {
@@ -26,17 +32,39 @@ def make_move(game_id, move):
         pos = m['pos']
 
         if current_board[pos] != ' ':
-            return {'id': game_id, 'board': current_board}
+            move_history.pop()
+            return {'id': game_id, 'board': current_board,
+                    'status': Status.INVALID}
 
         new_board = current_board[:pos] + m['char'] + \
             current_board[pos + 1:]
 
         if not solve(new_board):
-            return {'id': game_id, 'board': current_board}
+            move_history.pop()
+            return {'id': game_id, 'board': current_board,
+                    'status': Status.INVALID}
 
         current_board = new_board
 
-    return {'id': game_id, 'board': new_board}
+    if ' ' not in new_board:
+        return {'id': game_id, 'board': new_board, 'status': Status.COMPLETE}
+
+    return {'id': game_id, 'board': new_board, 'status': Status.INCOMPLETE}
+
+
+def set_state(game_id, board):
+    """Manually set the state of a board.
+
+    This should only be used for testing.
+    """
+    game_state[game_id]['board'] = board
+
+
+def get_state():
+    """Returns the state of every game
+    :returns: The current state of all games
+    """
+    return game_state
 
 
 def reset_all_state():

--- a/backend/sudokurace/views/game.py
+++ b/backend/sudokurace/views/game.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3.6
-from sanic.response import json, text
+from sanic.response import json
 from sudokurace import app
 from sudokurace.models import state
+from sudokurace.models.state import Status
 
 
 @app.route('/game.create', methods=['PUT', 'OPTIONS'])
@@ -13,13 +14,13 @@ async def root(req):
 @app.route('/game.move', methods=['POST'])
 async def move(req):
     if not req.json:
-        return text('No json received')
+        return json({'status': Status.INVALID, 'message': 'No json received'})
 
     if 'id' not in req.json:
-        return text('Json was missing id')
+        return json({'status': Status.INVALID, 'message': 'Missing id'})
 
     if 'move' not in req.json:
-        return text('Json was missing move')
+        return json({'status': Status.INVALID, 'message': 'Missing move'})
 
     game_id = req.json['id']
     game_move = req.json['move']

--- a/backend/sudokurace/views/game.py
+++ b/backend/sudokurace/views/game.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3.6
-
 from sanic.response import json, text
 
 from sudokurace import app
 from sudokurace.models import state
 
 
-@app.route('/game.create')
+@app.route('/game.create', methods=['PUT', 'OPTIONS'])
 async def root(req):
     created_game = state.create_game()
     return json(created_game)

--- a/backend/sudokurace/views/game.py
+++ b/backend/sudokurace/views/game.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3.6
 from sanic.response import json, text
-
 from sudokurace import app
 from sudokurace.models import state
 

--- a/backend/tests/test_core.py
+++ b/backend/tests/test_core.py
@@ -1,24 +1,44 @@
 from sudokurace.core import (
-    is_valid_board,
-    is_valid_set
+    solve,
+    display,
+    parse_grid
 )
 
 
-def test_is_valid_set():
-    assert is_valid_set('123456789') is True
-    assert is_valid_set('1234567  ') is True
-    assert is_valid_set('123 5678 ') is True
-    assert is_valid_set('5 4 3 1 2') is True
-    assert is_valid_set('') is False
-    assert is_valid_set('0        ') is False
-
-
-def test_is_valid_board():
+def test_solve():
     board = ('    735     6   9486 4     34   71             52   87     '
              '4 3297   8     413    ')
-    invalid_board = ('8   735     6   9486 4     34   71             52   '
-                     '87     4 3297   8     413    ')
+    solved = ''.join([c for c in solve(board).values()])
+    expected = ('421973568537681294869452713342867159798315426615249387'
+                '156794832973528641284136975')
+    assert expected == solved
 
-    assert is_valid_board(board) is True
-    assert is_valid_board(invalid_board) is False
-    assert is_valid_board('') is False
+
+def test_invalid_board():
+    board = ('1   735     6   9486 4     34   71             52   87     '
+             '4 3297   8     413    ')
+    assert False is solve(board)
+
+
+def test_display_looks_good():
+    board = ('    735     6   9486 4     34   71             52   87     '
+             '4 3297   8     413    ')
+    print()
+    displayed = display(parse_grid(board))
+    assert displayed == ('4 2 1 |9 7 3 |5 6 8 \n'
+                         '5 3 7 |6 8 1 |2 9 4 \n'
+                         '8 6 9 |4 5 2 |7 1 3 \n'
+                         '------+------+------\n'
+                         '3 4 2 |8 6 7 |1 5 9 \n'
+                         '7 9 8 |3 1 5 |4 2 6 \n'
+                         '6 1 5 |2 4 9 |3 8 7 \n'
+                         '------+------+------\n'
+                         '1 5 6 |7 9 4 |8 3 2 \n'
+                         '9 7 3 |5 2 8 |6 4 1 \n'
+                         '2 8 4 |1 3 6 |9 7 5 \n\n')
+
+
+def test_search_fallback():
+    board = ('4     8 5 3          7      2     6     8 4      1       6 '
+             '3 7 5  2     1 4      ')
+    solve(board)

--- a/backend/tests/test_core.py
+++ b/backend/tests/test_core.py
@@ -1,7 +1,7 @@
 from sudokurace.core import (
-    solve,
     display,
-    parse_grid
+    parse_grid,
+    solve
 )
 
 

--- a/backend/tests/test_state.py
+++ b/backend/tests/test_state.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3.6
+import logging
+
+import pytest
+from sudokurace.models.state import (
+    make_move,
+    create_game,
+    reset_all_state,
+    get_state,
+    set_state
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_state_fixture():
+    logging.info('resetting state')
+    reset_all_state()
+
+
+def test_getting_state():
+    assert {} == get_state()
+
+
+def test_invalid_move_is_not_recorded_in_move_history():
+    new_game = create_game()
+    game_id = new_game['id']
+    assert [] == new_game['move_history']
+    make_move(game_id, {'pos': 0, 'char': '8'})
+    assert [] == new_game['move_history']
+
+
+def test_that_attempting_a_move_on_a_used_spot_clears_history():
+    new_game = create_game()
+    game_id = new_game['id']
+    assert [] == new_game['move_history']
+    make_move(game_id, {'pos': 0, 'char': '4'})
+    assert [{'char': '4', 'pos': 0}] == new_game['move_history']
+    make_move(game_id, {'pos': 0, 'char': '1'})
+    assert [{'char': '4', 'pos': 0}] == new_game['move_history']
+
+
+def test_a_complete_board_has_status_complete():
+    board = ('  1973568537681294869452713342867159798315426615249387'
+             '156794832973528641284136975')
+    new_game = create_game()
+    game_id = new_game['id']
+    set_state(game_id, board)
+    assert board == get_state()[game_id]['board']
+
+    resp = make_move(game_id, {'pos': 1, 'char': '2'})
+    assert 'INCOMPLETE' == resp['status']
+
+    resp = make_move(game_id, {'pos': 0, 'char': '4'})
+    assert 'COMPLETE' == resp['status']

--- a/backend/tests/test_views.py
+++ b/backend/tests/test_views.py
@@ -1,8 +1,8 @@
+#!/usr/bin/env python3.6
 import json
 import logging
 
 import pytest
-
 from sudokurace import app
 from sudokurace.models.state import reset_all_state
 
@@ -60,20 +60,20 @@ def test_make_invalid_move():
 
 
 def test_make_valid_move():
-    req_json = {'id': 0, 'move': {'pos': 0, 'char': '1'}}
+    req_json = {'id': 0, 'move': {'pos': 0, 'char': '4'}}
     create_req, create_resp = app.test_client.put('/game.create')
     request, response = app.test_client.post('/game.move',
                                              data=json.dumps(req_json))
     as_json = json.loads(response.body)
     # The new board will have a 1 at the head of it
-    assert as_json['board'] == '1' + as_json['board'][1:]
+    assert as_json['board'] == '4' + as_json['board'][1:]
 
 
 def test_make_multiple_moves():
     app.test_client.put('/game.create')
 
     moves = [
-        {'id': 0, 'move': {'pos': 0, 'char': '1'}},
+        {'id': 0, 'move': {'pos': 0, 'char': '4'}},
         {'id': 0, 'move': {'pos': 1, 'char': '2'}}
     ]
 
@@ -81,14 +81,14 @@ def test_make_multiple_moves():
         request, response = app.test_client.post('/game.move',
                                                  data=json.dumps(move))
         as_json = json.loads(response.body)
-    assert as_json['board'] == '12' + as_json['board'][2:]
+    assert as_json['board'] == '42' + as_json['board'][2:]
 
 
 def test_that_trying_to_reuse_a_spot_fails():
     app.test_client.put('/game.create')
 
     moves = [
-        {'id': 0, 'move': {'pos': 0, 'char': '1'}},
+        {'id': 0, 'move': {'pos': 0, 'char': '4'}},
         {'id': 0, 'move': {'pos': 0, 'char': '2'}}
     ]
 
@@ -98,4 +98,4 @@ def test_that_trying_to_reuse_a_spot_fails():
         as_json = json.loads(response.body)
 
     # The second move should not be applied
-    assert as_json['board'] == '1' + as_json['board'][1:]
+    assert as_json['board'] == '4' + as_json['board'][1:]

--- a/backend/tests/test_views.py
+++ b/backend/tests/test_views.py
@@ -14,13 +14,13 @@ def reset_state_fixture():
 
 
 def test_game_create_not_null():
-    request, response = app.test_client.get('/game.create')
+    request, response = app.test_client.put('/game.create')
     as_json = json.loads(response.body)
     assert as_json
 
 
 def test_game_move_not_null():
-    app.test_client.get('/game.create')
+    app.test_client.put('/game.create')
     req_json = {'id': 0, 'move': {'pos': 0, 'char': '8'}}
     request, response = app.test_client.post('/game.move',
                                              data=json.dumps(req_json))
@@ -50,7 +50,7 @@ def test_game_move_missing_move():
 
 def test_make_invalid_move():
     req_json = {'id': 0, 'move': {'pos': 0, 'char': '8'}}
-    create_req, create_resp = app.test_client.get('/game.create')
+    create_req, create_resp = app.test_client.put('/game.create')
     created_board = json.loads(create_resp.body)['board']
     request, response = app.test_client.post('/game.move',
                                              data=json.dumps(req_json))
@@ -61,7 +61,7 @@ def test_make_invalid_move():
 
 def test_make_valid_move():
     req_json = {'id': 0, 'move': {'pos': 0, 'char': '1'}}
-    create_req, create_resp = app.test_client.get('/game.create')
+    create_req, create_resp = app.test_client.put('/game.create')
     request, response = app.test_client.post('/game.move',
                                              data=json.dumps(req_json))
     as_json = json.loads(response.body)
@@ -70,7 +70,7 @@ def test_make_valid_move():
 
 
 def test_make_multiple_moves():
-    app.test_client.get('/game.create')
+    app.test_client.put('/game.create')
 
     moves = [
         {'id': 0, 'move': {'pos': 0, 'char': '1'}},
@@ -85,7 +85,7 @@ def test_make_multiple_moves():
 
 
 def test_that_trying_to_reuse_a_spot_fails():
-    app.test_client.get('/game.create')
+    app.test_client.put('/game.create')
 
     moves = [
         {'id': 0, 'move': {'pos': 0, 'char': '1'}},

--- a/frontend/src/Board.jsx
+++ b/frontend/src/Board.jsx
@@ -13,10 +13,10 @@ class Board extends Component {
     };
   }
 
-  static async fetchResponseJson(url) {
+  static async fetchResponseJson(url, method = 'GET') {
     let board = '';
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, {method});
       const json = await response.json();
       board = await json.board;
     } catch (error) {
@@ -27,7 +27,7 @@ class Board extends Component {
   }
 
   componentDidMount() {
-    return Board.fetchResponseJson(this.props.url).then(board => {
+    return Board.fetchResponseJson(this.props.url, 'PUT').then(board => {
             if (!(board === undefined)) {
               this.setState({board});
             }


### PR DESCRIPTION
_**Ignore pytest cache**_

This especially comes up with I use ptw to auto run tests on new writes,
and there's no reason for it to be in the repository, so we can safely
ignore it.

_**Change game.create to PUT**_

CloudFront will cache GET requests, and since we're being lazy and we're
using the same URL to create games in a stateful server, using the GET
method on game.create was being cached, and so CloudFront would never
forward these requests to the actual server, which means we weren't
actually creating new games if the same client IP was hitting the
game.create endpoint. As such, let's update everything to use PUT which
is more canonical in REST interfaces, for creating a new resource.

Something to think about, is that PUTs are supposed to be idempotent,
and game.create is definitely not idempotent. Maybe this should actually
be a POST endpoint, but for now PUT works just fine. We're creating a
stateful server anyways, so how important is it that we stick to
standard definitions of the REST definitions which are supposed to only
be for stateless applications.

_**Implement Peter Norvig's sudoku solver**_

Peter uses constraint propagation which is backed by a DFS if the CP
fails to find a next move. It's very fast, and solves a board in
approximately 5ms.

_**Use pep8 import order style**_

I was using pep8 with my vim linter, but I forgot to set pep8 for the
actual build that runs in CircleCI.

_**Implement status on make.move responses**_

In order for the frontend to know how to handle a response from the
backend, we needed to add some indicator for the status of the board
after each move attempt.

Right now, there are three board statuses:
* 'INVALID' - The last move was incorrect, and so the frontend needs to
revert the move
* 'INCOMPLETE' - The board is in a valid state, but still has empty
spots
* 'COMPLETE' - The board is finished and the game is finished

